### PR TITLE
adds question component

### DIFF
--- a/src/css/_variables.css
+++ b/src/css/_variables.css
@@ -50,7 +50,7 @@
   --height-2: 2rem;
   --height-3: 4rem;
   --height-4: 6rem;
-  --height-5: 8rem;
+  --height-5: 11rem;
 
   --width-1: 1rem;
   --width-2: 2rem;

--- a/src/elm/Components/Questions.elm
+++ b/src/elm/Components/Questions.elm
@@ -1,0 +1,37 @@
+module Components.Questions exposing (..)
+
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Types exposing (..)
+
+
+questionTemplate : ( String, String ) -> Html Msg
+questionTemplate ( title, back ) =
+    section [ class "bg-light-blue m0-auto cover" ]
+        [ header []
+            [ h1 [ class "tc dark-gray raleway fw2 pa5-ns pa4 f2 m0-auto" ] [ text "In your own words" ]
+            ]
+        , a [ href ("#" ++ back), class "no-underline" ]
+            [ div [ class "w-60-l w-90 w-75-m center mid-gray fw1 raleway mb2" ]
+                [ img [ src "./assets/back.svg", class "h1 mr2" ] []
+                , text "Go Back"
+                ]
+            ]
+        , section [ class "w-60-l w-90 w-75-m center bg-white br3 shadow-1 pb5 pt3" ]
+            [ article [ class " w-90 center pv1" ]
+                [ h2 [ class "mid-gray raleway" ] [ text "One video is worth 1000 (written!) words..." ]
+                , p [ class "mid-gray raleway fw1" ] [ text "In this section we would like you to make a short video or voice recording of yourself, telling us in your own words what you are looking for." ]
+                , h3 [ class "center tc dark-gray pv4" ] [ text title ]
+                , div [ class "flex flex-row flex-wrap center tc w-75 justify-between mr1" ]
+                    [ div [ class "w-50-ns w-100 mid-gray flex flex-column mv2" ]
+                        [ img [ src "./assets/rec_video.svg", class "h5 mb2" ] []
+                        , text "Click to Record Video"
+                        ]
+                    , div [ class "w-50-ns w-100 mid-gray flex flex-column mv2" ]
+                        [ img [ src "./assets/rec_audio.svg", class "h5 mb2" ] []
+                        , text "Click to Record Audio"
+                        ]
+                    ]
+                ]
+            ]
+        ]

--- a/src/elm/Routes/AboutYou.elm
+++ b/src/elm/Routes/AboutYou.elm
@@ -12,7 +12,7 @@ aboutYou model =
         [ header []
             [ h1 [ class "tc dark-gray raleway fw2 pa5-ns pa4 f2 m0-auto" ] [ text "Tell us about you" ]
             ]
-        , section [ class "w-50-l w-90 w-75-m center bg-white br3 shadow-1 pv3" ]
+        , section [ class "w-60-l w-90 w-75-m center bg-white br3 shadow-1 pv3 mb4" ]
             [ article [ class " w-90 center pv1" ]
                 [ div []
                     [ img [ src "./assets/about_you.svg", class "absolute minus-margin h3" ] []

--- a/src/elm/Routes/NextRole.elm
+++ b/src/elm/Routes/NextRole.elm
@@ -1,0 +1,17 @@
+module Routes.NextRole exposing (..)
+
+import Components.Questions exposing (..)
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Html.Events exposing (..)
+import Types exposing (..)
+
+
+nextRole : Model -> Html Msg
+nextRole model =
+    div []
+        [ questionTemplate
+            ( "What are you looking for in your next role?"
+            , "aboutYou"
+            )
+        ]

--- a/src/elm/State.elm
+++ b/src/elm/State.elm
@@ -10,7 +10,7 @@ import Types exposing (..)
 
 initModel : Model
 initModel =
-    { route = AboutYouRoute }
+    { route = NextRoleRoute }
 
 
 
@@ -25,6 +25,9 @@ getRoute hash =
 
         "#aboutYou" ->
             AboutYouRoute
+
+        "#nextRole" ->
+            NextRoleRoute
 
         _ ->
             HelloRoute

--- a/src/elm/Types.elm
+++ b/src/elm/Types.elm
@@ -10,6 +10,7 @@ import Navigation
 type Route
     = HelloRoute
     | AboutYouRoute
+    | NextRoleRoute
 
 
 type alias Model =

--- a/src/elm/View.elm
+++ b/src/elm/View.elm
@@ -4,6 +4,7 @@ import Html exposing (..)
 import Html.Attributes exposing (..)
 import Routes.AboutYou exposing (..)
 import Routes.Hello exposing (..)
+import Routes.NextRole exposing (..)
 import Types exposing (..)
 
 
@@ -17,7 +18,10 @@ view model =
 
                 AboutYouRoute ->
                     aboutYou model
+
+                NextRoleRoute ->
+                    nextRole model
     in
-    div [ class "w-100 fixed overflow-y-scroll top-0 bottom-0", id "container" ]
+    div [ class "w-100 fixed overflow-y-scroll top-0 bottom-0 bg-light-blue m0-auto cover", id "container" ]
         [ page
         ]


### PR DESCRIPTION
title and back route can be edited. Does not include gray button at bottom of design - this will be a component as well. 
relates #26 
example of component on 'next role' page: 
![image](https://user-images.githubusercontent.com/26116988/35339072-8ab369ce-0117-11e8-86b8-95047edfe82a.png)
